### PR TITLE
Add timeseries endpoint and chart

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -1,5 +1,5 @@
 /* global avdData, wp */
-const { createElement: h, render, useState, useEffect } = wp.element;
+const { createElement: h, render, useState, useEffect, useRef } = wp.element;
 
 const KPI = ({ label, value }) =>
     h('div', { className: 'avd-card' }, [
@@ -9,6 +9,9 @@ const KPI = ({ label, value }) =>
 
 const App = () => {
     const [kpi, setKpi] = useState(null);
+    const [series, setSeries] = useState(null);
+    const canvasRef = useRef(null);
+    const chartRef = useRef(null);
 
     useEffect(() => {
         fetch(`${avdData.root}kpi`, {
@@ -16,17 +19,39 @@ const App = () => {
         })
             .then(r => r.json())
             .then(setKpi);
+
+        fetch(`${avdData.root}timeseries?metric=revenue&from=2025-07-02&to=2025-07-02&gran=hour`, {
+            headers: { 'X-WP-Nonce': avdData.nonce }
+        })
+            .then(r => r.json())
+            .then(setSeries);
     }, []);
+
+    useEffect(() => {
+        if (!series || !canvasRef.current) return;
+        if (chartRef.current) chartRef.current.destroy();
+        chartRef.current = new Chart(canvasRef.current.getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: series.map(p => p.label),
+                datasets: [{ label: 'Revenue', data: series.map(p => p.value) }]
+            },
+            options: { responsive: true }
+        });
+    }, [series]);
 
     if (!kpi) return h('p', null, 'Loading KPIs…');
 
-    return h('div', { className: 'avd-kpis' }, [
-        h(KPI, { label: 'Inventory',        value: kpi.inventory }),
-        h(KPI, { label: 'Impression',       value: kpi.impression }),
-        h(KPI, { label: 'Revenue',          value: `$${kpi.revenue}` }),
-        h(KPI, { label: 'CPM',              value: `$${kpi.cpm}` }),
-        h(KPI, { label: 'CTR',              value: `${kpi.ctr}%` }),
-        h(KPI, { label: 'Completion Rate',  value: `${kpi.completion_rate}%` }),
+    return h('div', null, [
+        h('div', { className: 'avd-kpis' }, [
+            h(KPI, { label: 'Inventory',        value: kpi.inventory }),
+            h(KPI, { label: 'Impression',       value: kpi.impression }),
+            h(KPI, { label: 'Revenue',          value: `$${kpi.revenue}` }),
+            h(KPI, { label: 'CPM',              value: `$${kpi.cpm}` }),
+            h(KPI, { label: 'CTR',              value: `${kpi.ctr}%` }),
+            h(KPI, { label: 'Completion Rate',  value: `${kpi.completion_rate}%` }),
+        ]),
+        h('canvas', { id: 'avd-rev-chart', ref: canvasRef })
     ]);
 };
 

--- a/includes/class-av-rest.php
+++ b/includes/class-av-rest.php
@@ -11,6 +11,12 @@ class REST {
             'callback' => [ __CLASS__, 'kpi' ],
             'permission_callback' => function() { return current_user_can( 'manage_options' ); },
         ] );
+
+        register_rest_route( 'av/v1', '/timeseries', [
+            'methods'  => WP_REST_Server::READABLE,
+            'callback' => [ __CLASS__, 'timeseries' ],
+            'permission_callback' => function() { return current_user_can( 'manage_options' ); },
+        ] );
     }
 
     public static function kpi() {
@@ -21,6 +27,14 @@ class REST {
             'cpm'             => 1.41,
             'ctr'             => 0,
             'completion_rate' => 54.55,
+        ];
+    }
+
+    public static function timeseries( $request ) {
+        return [
+            [ 'label' => '2025-07-02 00h', 'value' => 0.2 ],
+            [ 'label' => '2025-07-02 01h', 'value' => 0.3 ],
+            [ 'label' => '2025-07-02 02h', 'value' => 0.1 ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- expose `/timeseries` data via REST API
- fetch timeseries data in dashboard
- draw revenue bar chart with Chart.js

## Testing
- `php -l includes/class-av-rest.php`
- `node --check assets/js/dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_686797ed516c8328b68cc619f06d5c13