### PR TITLE
Add data sources admin page and REST API

### DIFF
--- a/admin/class-av-admin.php
+++ b/admin/class-av-admin.php
@@ -18,11 +18,30 @@ class Admin {
             'dashicons-chart-area',
             80
         );
+
+        add_submenu_page(
+            'avd-dashboard',
+            'Data Sources',
+            'Data Sources',
+            'manage_options',
+            'avd-datasources',
+            [ __CLASS__, 'data_sources_page' ]
+        );
     }
 
     public static function dashboard_page() {
         echo '<div class="wrap"><h1>AV Dashboard</h1>';
         include AVD_PATH . 'admin/views/dashboard.php';
+        echo '</div>';
+    }
+
+    public static function data_sources_page() {
+        global $wpdb;
+        $table   = $wpdb->prefix . 'av_datasources';
+        $sources = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
+
+        echo '<div class="wrap"><h1>Data Sources</h1>';
+        include AVD_PATH . 'admin/views/data-sources.php';
         echo '</div>';
     }
 

--- a/admin/views/data-sources.php
+++ b/admin/views/data-sources.php
@@ -1,0 +1,35 @@
+<?php
+/** @var array $sources */
+?>
+<table class="widefat">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Active</th>
+            <th>Last Run</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ( ! empty( $sources ) ) : ?>
+        <?php foreach ( $sources as $src ) : ?>
+            <tr>
+                <td><?php echo esc_html( $src->id ); ?></td>
+                <td><?php echo esc_html( $src->name ); ?></td>
+                <td><?php echo esc_html( $src->type ); ?></td>
+                <td><?php echo $src->is_active ? 'Yes' : 'No'; ?></td>
+                <td><?php echo esc_html( $src->last_run ); ?></td>
+                <td>
+                    <button>Edit</button>
+                    <button>Delete</button>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr><td colspan="6">No data sources found.</td></tr>
+    <?php endif; ?>
+    </tbody>
+</table>
+<p><button>Add New</button></p>

--- a/aniview-dashboard.php
+++ b/aniview-dashboard.php
@@ -15,5 +15,23 @@ define( 'AVD_VER',  '0.1.0' );
 require_once AVD_PATH . 'admin/class-av-admin.php';
 require_once AVD_PATH . 'includes/class-av-rest.php';
 
-// Nothing yet on activation but you can hook table creation here
-register_activation_hook( __FILE__, function () {} );
+register_activation_hook( __FILE__, 'avd_activate' );
+
+function avd_activate() {
+    global $wpdb;
+    $table_name      = $wpdb->prefix . 'av_datasources';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+    dbDelta("CREATE TABLE {$table_name} (
+        id bigint(20) unsigned NOT NULL auto_increment,
+        name varchar(191) NOT NULL,
+        type varchar(50) NOT NULL,
+        config longtext NULL,
+        is_active tinyint(1) NOT NULL default 1,
+        last_run datetime NULL,
+        created datetime NOT NULL default CURRENT_TIMESTAMP,
+        PRIMARY KEY  (id)
+    ) {$charset_collate};");
+}

--- a/includes/class-av-rest.php
+++ b/includes/class-av-rest.php
@@ -4,12 +4,38 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 use WP_REST_Server;
 
+use WP_REST_Request;
+
 class REST {
     public static function register() {
         register_rest_route( 'av/v1', '/kpi', [
             'methods'  => WP_REST_Server::READABLE,
             'callback' => [ __CLASS__, 'kpi' ],
             'permission_callback' => function() { return current_user_can( 'manage_options' ); },
+        ] );
+
+        register_rest_route( 'av/v1', '/datasources', [
+            'methods'  => WP_REST_Server::READABLE,
+            'callback' => [ __CLASS__, 'get_datasources' ],
+            'permission_callback' => [ __CLASS__, 'check_permissions' ],
+        ] );
+
+        register_rest_route( 'av/v1', '/datasources', [
+            'methods'  => WP_REST_Server::CREATABLE,
+            'callback' => [ __CLASS__, 'create_datasource' ],
+            'permission_callback' => [ __CLASS__, 'check_permissions' ],
+        ] );
+
+        register_rest_route( 'av/v1', '/datasources/(?P<id>\d+)', [
+            'methods'  => WP_REST_Server::EDITABLE,
+            'callback' => [ __CLASS__, 'update_datasource' ],
+            'permission_callback' => [ __CLASS__, 'check_permissions' ],
+        ] );
+
+        register_rest_route( 'av/v1', '/datasources/(?P<id>\d+)', [
+            'methods'  => WP_REST_Server::DELETABLE,
+            'callback' => [ __CLASS__, 'delete_datasource' ],
+            'permission_callback' => [ __CLASS__, 'check_permissions' ],
         ] );
     }
 
@@ -22,6 +48,74 @@ class REST {
             'ctr'             => 0,
             'completion_rate' => 54.55,
         ];
+    }
+
+    public static function check_permissions( $request ) {
+        $nonce = $request->get_header( 'X-WP-Nonce' );
+        if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+            return new \WP_Error( 'rest_nonce', 'Invalid nonce', [ 'status' => 403 ] );
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return new \WP_Error( 'rest_forbidden', 'Forbidden', [ 'status' => 403 ] );
+        }
+        return true;
+    }
+
+    public static function get_datasources() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'av_datasources';
+        return $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
+    }
+
+    public static function create_datasource( WP_REST_Request $request ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'av_datasources';
+
+        $data = [
+            'name'      => sanitize_text_field( $request['name'] ),
+            'type'      => sanitize_text_field( $request['type'] ),
+            'config'    => wp_json_encode( $request->get_param( 'config' ) ),
+            'is_active' => $request->get_param( 'is_active' ) ? 1 : 0,
+        ];
+
+        $wpdb->insert( $table, $data );
+        $id = $wpdb->insert_id;
+
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id=%d", $id ) );
+    }
+
+    public static function update_datasource( WP_REST_Request $request ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'av_datasources';
+        $id    = (int) $request['id'];
+
+        $data = [];
+        if ( $request->has_param( 'name' ) ) {
+            $data['name'] = sanitize_text_field( $request['name'] );
+        }
+        if ( $request->has_param( 'type' ) ) {
+            $data['type'] = sanitize_text_field( $request['type'] );
+        }
+        if ( $request->has_param( 'config' ) ) {
+            $data['config'] = wp_json_encode( $request->get_param( 'config' ) );
+        }
+        if ( $request->has_param( 'is_active' ) ) {
+            $data['is_active'] = $request->get_param( 'is_active' ) ? 1 : 0;
+        }
+
+        if ( ! empty( $data ) ) {
+            $wpdb->update( $table, $data, [ 'id' => $id ] );
+        }
+
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id=%d", $id ) );
+    }
+
+    public static function delete_datasource( WP_REST_Request $request ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'av_datasources';
+        $id    = (int) $request['id'];
+        $wpdb->delete( $table, [ 'id' => $id ] );
+        return [ 'deleted' => true ];
     }
 }
 


### PR DESCRIPTION
## Summary
- create `wp_av_datasources` table on plugin activation
- add Data Sources submenu with a listing template
- add REST endpoints to manage datasources

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686798b2f87c8328936aab9886488589