### PR TITLE
Add metrics ingestion system

### DIFF
--- a/aniview-dashboard.php
+++ b/aniview-dashboard.php
@@ -14,6 +14,11 @@ define( 'AVD_VER',  '0.1.0' );
 
 require_once AVD_PATH . 'admin/class-av-admin.php';
 require_once AVD_PATH . 'includes/class-av-rest.php';
+require_once AVD_PATH . 'includes/class-av-ingest.php';
 
-// Nothing yet on activation but you can hook table creation here
-register_activation_hook( __FILE__, function () {} );
+register_activation_hook( __FILE__, function () {
+    \AVD\Ingest::install();
+    \AVD\Ingest::schedule();
+} );
+
+\AVD\Ingest::init();

--- a/includes/class-av-ingest.php
+++ b/includes/class-av-ingest.php
@@ -1,0 +1,68 @@
+<?php
+namespace AVD;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class Ingest {
+    public static function init() {
+        add_action( 'avd_ingest_hourly', [ __CLASS__, 'run' ] );
+    }
+
+    public static function install() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'av_metrics';
+        $charset = $wpdb->get_charset_collate();
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $sql = "CREATE TABLE $table (
+            id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+            datasource_id bigint(20) unsigned NOT NULL,
+            metric_date date NOT NULL,
+            hour tinyint(2) NOT NULL,
+            inventory bigint(20) unsigned NOT NULL,
+            impression bigint(20) unsigned NOT NULL,
+            revenue decimal(10,2) NOT NULL,
+            cpm decimal(10,2) NOT NULL,
+            ctr decimal(10,2) NOT NULL,
+            completion_rate decimal(10,2) NOT NULL,
+            PRIMARY KEY  (id),
+            KEY datasource_date_hour (datasource_id, metric_date, hour)
+        ) $charset;";
+        dbDelta( $sql );
+    }
+
+    public static function schedule() {
+        if ( ! wp_next_scheduled( 'avd_ingest_hourly' ) ) {
+            wp_schedule_event( time(), 'hourly', 'avd_ingest_hourly' );
+        }
+    }
+
+    public static function run() {
+        global $wpdb;
+        $ds_table = $wpdb->prefix . 'av_datasources';
+        $metrics = $wpdb->prefix . 'av_metrics';
+
+        $sources = $wpdb->get_results( "SELECT id FROM $ds_table WHERE active = 1" );
+        foreach ( $sources as $ds ) {
+            $inventory  = rand( 50, 100 );
+            $impression = rand( 0, $inventory );
+            $revenue    = round( $impression * 0.02, 2 );
+            $cpm        = $impression ? round( ( $revenue / $impression ) * 1000, 2 ) : 0;
+            $ctr        = $inventory ? round( ( $impression / $inventory ) * 100, 2 ) : 0;
+            $completion = rand( 0, 100 );
+
+            $wpdb->insert( $metrics, [
+                'datasource_id'   => $ds->id,
+                'metric_date'     => current_time( 'Y-m-d' ),
+                'hour'            => (int) current_time( 'H' ),
+                'inventory'       => $inventory,
+                'impression'      => $impression,
+                'revenue'         => $revenue,
+                'cpm'             => $cpm,
+                'ctr'             => $ctr,
+                'completion_rate' => $completion,
+            ], [
+                '%d','%s','%d','%d','%d','%f','%f','%f','%f'
+            ] );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Ingest class to create a metrics table and insert dummy data
- load the Ingest class and schedule cron on activation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867995c9d3c83289680d199d6d1ac92