### PR TITLE
Add ranking endpoints and responsive dashboard

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -21,3 +21,49 @@
     font-size:18px;
     font-weight:600;
 }
+
+.avd-controls{
+    margin:16px 0;
+    display:flex;
+    gap:8px;
+    flex-wrap:wrap;
+}
+
+.avd-charts{
+    display:grid;
+    grid-template-columns:repeat(2,1fr);
+    gap:16px;
+}
+.avd-chart{
+    background:#fff;
+    border:1px solid #ddd;
+    border-radius:6px;
+    padding:12px;
+    height:300px;
+}
+
+.avd-tables{
+    margin-top:16px;
+    display:grid;
+    grid-template-columns:1fr 1fr 1fr;
+    gap:16px;
+}
+.avd-table{
+    width:100%;
+    border-collapse:collapse;
+    background:#fff;
+    border:1px solid #ddd;
+    border-radius:6px;
+}
+.avd-table th,
+.avd-table td{
+    padding:8px;
+    border-bottom:1px solid #eee;
+    text-align:left;
+}
+.avd-table th{background:#f9f9f9;}
+
+@media(max-width:600px){
+    .avd-charts{grid-template-columns:1fr;}
+    .avd-tables{grid-template-columns:1fr;}
+}

--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -1,5 +1,5 @@
-/* global avdData, wp */
-const { createElement: h, render, useState, useEffect } = wp.element;
+/* global avdData, wp, Chart */
+const { createElement: h, render, useState, useEffect, useRef } = wp.element;
 
 const KPI = ({ label, value }) =>
     h('div', { className: 'avd-card' }, [
@@ -7,26 +7,158 @@ const KPI = ({ label, value }) =>
         h('span', null, value)
     ]);
 
-const App = () => {
-    const [kpi, setKpi] = useState(null);
+const ChartCanvas = ({ id }) => h('canvas', { id });
 
-    useEffect(() => {
-        fetch(`${avdData.root}kpi`, {
-            headers: { 'X-WP-Nonce': avdData.nonce }
-        })
+const Table = ({ data }) =>
+    h('table', { className: 'avd-table' }, [
+        h('thead', null,
+            h('tr', null, [
+                h('th', null, 'Name'),
+                h('th', null, 'Impressions'),
+                h('th', null, 'Revenue')
+            ])
+        ),
+        h('tbody', null,
+            data.map((row, i) =>
+                h('tr', { key: i }, [
+                    h('td', null, row.label),
+                    h('td', null, row.impression),
+                    h('td', null, `$${row.revenue}`)
+                ])
+            )
+        )
+    ]);
+
+const App = () => {
+    const today = new Date().toISOString().slice(0, 10);
+
+    const [start, setStart]         = useState(today);
+    const [end, setEnd]             = useState(today);
+    const [granularity, setGran]    = useState('daily');
+    const [kpi, setKpi]             = useState(null);
+    const [country, setCountry]     = useState([]);
+    const [os, setOs]               = useState([]);
+    const [channel, setChannel]     = useState([]);
+
+    const revRef    = useRef(null);
+    const perfRef   = useRef(null);
+    const countryRef= useRef(null);
+    const osRef     = useRef(null);
+    const channelRef= useRef(null);
+
+    const fetchData = () => {
+        const params = `?start=${start}&end=${end}&granularity=${granularity}`;
+        fetch(`${avdData.root}kpi${params}`, { headers: { 'X-WP-Nonce': avdData.nonce }})
             .then(r => r.json())
             .then(setKpi);
-    }, []);
+        ['country','os','channel'].forEach(dim => {
+            fetch(`${avdData.root}rank?dimension=${dim}&start=${start}&end=${end}`, { headers: { 'X-WP-Nonce': avdData.nonce }})
+                .then(r => r.json())
+                .then(data => {
+                    if (dim === 'country') setCountry(data);
+                    if (dim === 'os') setOs(data);
+                    if (dim === 'channel') setChannel(data);
+                });
+        });
+    };
 
-    if (!kpi) return h('p', null, 'Loading KPIs…');
+    useEffect(fetchData, [start, end, granularity]);
 
-    return h('div', { className: 'avd-kpis' }, [
-        h(KPI, { label: 'Inventory',        value: kpi.inventory }),
-        h(KPI, { label: 'Impression',       value: kpi.impression }),
-        h(KPI, { label: 'Revenue',          value: `$${kpi.revenue}` }),
-        h(KPI, { label: 'CPM',              value: `$${kpi.cpm}` }),
-        h(KPI, { label: 'CTR',              value: `${kpi.ctr}%` }),
-        h(KPI, { label: 'Completion Rate',  value: `${kpi.completion_rate}%` }),
+    useEffect(() => {
+        if (!kpi) return;
+
+        const dates = kpi.series.map(s => s.date);
+        const revenueData = kpi.series.map(s => s.revenue);
+        const inventoryData = kpi.series.map(s => s.inventory);
+        const impressionData = kpi.series.map(s => s.impression);
+
+        new Chart(revRef.current, {
+            type: 'line',
+            data: { labels: dates, datasets: [{ label: 'Revenue', data: revenueData, borderColor: '#3e95cd', fill: false }] },
+            options: { responsive: true, maintainAspectRatio: false }
+        });
+
+        new Chart(perfRef.current, {
+            type: 'line',
+            data: { labels: dates, datasets: [
+                { label: 'Inventory', data: inventoryData, borderColor: '#8e5ea2', fill: false },
+                { label: 'Impression', data: impressionData, borderColor: '#3cba9f', fill: false }
+            ] },
+            options: { responsive: true, maintainAspectRatio: false }
+        });
+    }, [kpi]);
+
+    useEffect(() => {
+        if (country.length)
+            new Chart(countryRef.current, {
+                type: 'bar',
+                data: {
+                    labels: country.map(r => r.label),
+                    datasets: [
+                        { label: 'Impression', data: country.map(r => r.impression), backgroundColor: '#3e95cd' },
+                        { label: 'Revenue', data: country.map(r => r.revenue), backgroundColor: '#8e5ea2' }
+                    ]
+                },
+                options: { responsive: true, maintainAspectRatio: false }
+            });
+        if (os.length)
+            new Chart(osRef.current, {
+                type: 'bar',
+                data: {
+                    labels: os.map(r => r.label),
+                    datasets: [
+                        { label: 'Impression', data: os.map(r => r.impression), backgroundColor: '#3cba9f' },
+                        { label: 'Revenue', data: os.map(r => r.revenue), backgroundColor: '#e8c3b9' }
+                    ]
+                },
+                options: { responsive: true, maintainAspectRatio: false }
+            });
+        if (channel.length)
+            new Chart(channelRef.current, {
+                type: 'bar',
+                data: {
+                    labels: channel.map(r => r.label),
+                    datasets: [
+                        { label: 'Impression', data: channel.map(r => r.impression), backgroundColor: '#c45850' },
+                        { label: 'Revenue', data: channel.map(r => r.revenue), backgroundColor: '#3e95cd' }
+                    ]
+                },
+                options: { responsive: true, maintainAspectRatio: false }
+            });
+    }, [country, os, channel]);
+
+    if (!kpi) return h('p', null, 'Loading…');
+
+    return h('div', null, [
+        h('div', { className: 'avd-controls' }, [
+            h('input', { type: 'date', value: start, onChange: e => setStart(e.target.value) }),
+            h('input', { type: 'date', value: end, onChange: e => setEnd(e.target.value) }),
+            h('select', { value: granularity, onChange: e => setGran(e.target.value) }, [
+                h('option', { value: 'daily'  }, 'Daily'),
+                h('option', { value: 'weekly' }, 'Weekly'),
+                h('option', { value: 'monthly'}, 'Monthly')
+            ])
+        ]),
+        h('div', { className: 'avd-kpis' }, [
+            h(KPI, { label: 'Inventory',        value: kpi.inventory }),
+            h(KPI, { label: 'Impression',       value: kpi.impression }),
+            h(KPI, { label: 'Revenue',          value: `$${kpi.revenue}` }),
+            h(KPI, { label: 'CPM',              value: `$${kpi.cpm}` }),
+            h(KPI, { label: 'CTR',              value: `${kpi.ctr}%` }),
+            h(KPI, { label: 'Completion Rate',  value: `${kpi.completion_rate}%` })
+        ]),
+        h('div', { className: 'avd-charts' }, [
+            h('div', { className: 'avd-chart' }, h(ChartCanvas, { id: 'rev', ref: revRef })),
+            h('div', { className: 'avd-chart' }, h(ChartCanvas, { id: 'perf', ref: perfRef })),
+            h('div', { className: 'avd-chart' }, h(ChartCanvas, { id: 'country', ref: countryRef })),
+            h('div', { className: 'avd-chart' }, h(ChartCanvas, { id: 'os', ref: osRef })),
+            h('div', { className: 'avd-chart' }, h(ChartCanvas, { id: 'channel', ref: channelRef }))
+        ]),
+        h('div', { className: 'avd-tables' }, [
+            h(Table, { data: country }),
+            h(Table, { data: os }),
+            h(Table, { data: channel })
+        ])
     ]);
 };
 

--- a/includes/class-av-rest.php
+++ b/includes/class-av-rest.php
@@ -11,9 +11,32 @@ class REST {
             'callback' => [ __CLASS__, 'kpi' ],
             'permission_callback' => function() { return current_user_can( 'manage_options' ); },
         ] );
+
+        register_rest_route( 'av/v1', '/rank', [
+            'methods'  => WP_REST_Server::READABLE,
+            'callback' => [ __CLASS__, 'rank' ],
+            'permission_callback' => function() { return current_user_can( 'manage_options' ); },
+            'args' => [
+                'dimension' => [ 'required' => true ],
+                'start'     => [],
+                'end'       => [],
+            ],
+        ] );
     }
 
-    public static function kpi() {
+    public static function kpi( $request ) {
+        // Example static data for demo purposes only
+        $series = [];
+        for ( $i = 6; $i >= 0; $i-- ) {
+            $date  = date( 'Y-m-d', strtotime( "-$i days" ) );
+            $series[] = [
+                'date'       => $date,
+                'revenue'    => rand(1, 10),
+                'inventory'  => rand(50, 150),
+                'impression' => rand(20, 100),
+            ];
+        }
+
         return [
             'inventory'       => 79,
             'impression'      => 11,
@@ -21,7 +44,52 @@ class REST {
             'cpm'             => 1.41,
             'ctr'             => 0,
             'completion_rate' => 54.55,
+            'series'          => $series,
         ];
+    }
+
+    public static function rank( $request ) {
+        $dimension = $request->get_param( 'dimension' );
+
+        $data = [];
+        switch ( $dimension ) {
+            case 'country':
+                $data = [
+                    [ 'label' => 'US',    'impression' => 1200, 'revenue' => 60 ],
+                    [ 'label' => 'UK',    'impression' => 900,  'revenue' => 45 ],
+                    [ 'label' => 'CA',    'impression' => 850,  'revenue' => 40 ],
+                    [ 'label' => 'DE',    'impression' => 800,  'revenue' => 38 ],
+                    [ 'label' => 'FR',    'impression' => 780,  'revenue' => 35 ],
+                    [ 'label' => 'ES',    'impression' => 760,  'revenue' => 32 ],
+                    [ 'label' => 'IT',    'impression' => 740,  'revenue' => 30 ],
+                    [ 'label' => 'IN',    'impression' => 700,  'revenue' => 28 ],
+                    [ 'label' => 'BR',    'impression' => 650,  'revenue' => 25 ],
+                    [ 'label' => 'AU',    'impression' => 600,  'revenue' => 22 ],
+                ];
+                break;
+
+            case 'os':
+                $data = [
+                    [ 'label' => 'Windows', 'impression' => 1500, 'revenue' => 70 ],
+                    [ 'label' => 'iOS',     'impression' => 1100, 'revenue' => 60 ],
+                    [ 'label' => 'Android', 'impression' => 1000, 'revenue' => 55 ],
+                    [ 'label' => 'Mac',     'impression' => 900,  'revenue' => 50 ],
+                    [ 'label' => 'Linux',   'impression' => 400,  'revenue' => 20 ],
+                ];
+                break;
+
+            case 'channel':
+                $data = [
+                    [ 'label' => 'Display',   'impression' => 1600, 'revenue' => 80 ],
+                    [ 'label' => 'Video',     'impression' => 1400, 'revenue' => 70 ],
+                    [ 'label' => 'Native',    'impression' => 1000, 'revenue' => 55 ],
+                    [ 'label' => 'Instream',  'impression' => 800,  'revenue' => 45 ],
+                    [ 'label' => 'Rewarded',  'impression' => 500,  'revenue' => 25 ],
+                ];
+                break;
+        }
+
+        return array_slice( $data, 0, 10 );
     }
 }
 


### PR DESCRIPTION
## Summary
- add `/rank` REST endpoint with sample data
- expand `/kpi` endpoint with series data
- show KPI metrics with date range controls
- add revenue, performance, and ranking charts
- display ranking tables
- style dashboard layout with responsive CSS grid

## Testing
- `php` command was unavailable so PHP linting couldn't run


------
https://chatgpt.com/codex/tasks/task_e_6867ba6f2a0483289b6d0c490d106675